### PR TITLE
accept display_method from parameters

### DIFF
--- a/lib/active_admin_search.rb
+++ b/lib/active_admin_search.rb
@@ -23,7 +23,7 @@ module ActiveAdminSearch # :nodoc:
       page_limit = dsl_option_for(options, :limit)
       skip_pagination = dsl_option_for(options, :skip_pagination)
       highlight = dsl_option_for(options, :highlight)
-      display_method = dsl_option_for(options, :display_method)
+      display_method = params.fetch(:display_method) { dsl_option_for(options, :display_method) }
       default_scope = Array(dsl_option_for(options, :default_scope))
       includes = Array(dsl_option_for(options, :includes))
       value_method = dsl_option_for(options, :value_method)

--- a/spec/requests/display_method_request_spec.rb
+++ b/spec/requests/display_method_request_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe 'DSL option :display_method' do
     end
   end
 
+  context 'when set display_method from get parameter' do
+    before do
+      ActiveAdmin.register Author, as: 'display_method' do; active_admin_search! end
+      Rails.application.reload_routes!
+    end
+
+    subject { get "/admin/display_methods/search?term=#{term}&display_method=display_name_ajax" }
+
+    it 'should have additional display method' do
+      subject
+      expect(response_json).to match_array hash_including(value: record.id, text: record.display_name_ajax)
+    end
+  end
+
   # TODO need to implement raise if not have defined display_method in model
   xcontext 'search by unknown display_method' do
     before do


### PR DESCRIPTION
to prevent double definition we implement feature to accept
display_method from parameters like this
display_method = params.fetch(:display_method) { dsl_option_for(options,
:display_method) }